### PR TITLE
Implement runtime task logic

### DIFF
--- a/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/EntrypointTest.java
+++ b/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/EntrypointTest.java
@@ -1,10 +1,43 @@
 package com.amannmalik.workflow.runtime;
 
+import io.serverlessworkflow.api.types.WaitTask;
+import io.serverlessworkflow.api.types.Task;
+import io.serverlessworkflow.api.types.TaskItem;
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.api.types.Document;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import dev.restate.sdk.WorkflowContext;
+import java.time.Duration;
+import java.util.List;
 
 class EntrypointTest {
+    @AfterEach
+    void shutdown() {
+    }
+
+
     @Test
-    void testSampleLoadingAndExecution() {
-        // TODO: load and configure the restate runtime with sample.yaml and execute the runtime using wiremock to mock the fake endpoints described in the DSL
+    void testSetAndWaitTasks() {
+        WorkflowContext ctx = Mockito.mock(WorkflowContext.class);
+        Mockito.doNothing().when(ctx).sleep(Mockito.any());
+
+        WaitTask wt = new WaitTask();
+        var to = new io.serverlessworkflow.api.types.TimeoutAfter();
+        var di = new io.serverlessworkflow.api.types.DurationInline();
+        di.setSeconds(1);
+        to.setDurationInline(di);
+        wt.setWait(to);
+
+        Task task = new Task();
+        task.setWaitTask(wt);
+
+        var wf = new Workflow(new Document(), List.of(new TaskItem("w", task)));
+
+        Entrypoint ep = new Entrypoint();
+        ep.run(ctx, wf);
+
+        Mockito.verify(ctx).sleep(Duration.ofSeconds(1));
     }
 }


### PR DESCRIPTION
## Summary
- add basic implementations for HTTP, switch, try/catch and wait tasks
- add simple test covering wait task execution

## Testing
- `./mvnw -DtrimStackTrace=false test`

------
https://chatgpt.com/codex/tasks/task_e_684c5a720c088324945a3d2877d15c75