### PR TITLE
Implement cron-based workflow execution

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/Entrypoint.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/Entrypoint.java
@@ -3,6 +3,7 @@ package com.amannmalik.workflow.runtime;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.endpoint.Endpoint;
 import dev.restate.sdk.http.vertx.RestateHttpServer;
+import java.util.Optional;
 import io.serverlessworkflow.api.types.Task;
 import io.serverlessworkflow.api.types.Workflow;
 import org.slf4j.Logger;
@@ -13,11 +14,41 @@ public class Entrypoint {
 
     private static final Logger log = LoggerFactory.getLogger(Entrypoint.class);
 
+    /**
+     * Entry point for workflow definitions. If the workflow defines a cron
+     * schedule, this method creates a {@link CronExample.Job} to execute the
+     * workflow according to that schedule. Otherwise the workflow tasks are
+     * executed immediately.
+     */
     @dev.restate.sdk.annotation.Workflow
     public void run(WorkflowContext ctx, Workflow input) {
-        // TODO: figure out how this maps to a durable schedule through restate
         var schedule = input.getSchedule();
+        if (schedule != null && schedule.getCron() != null) {
+            CronExample.JobRequest request = new CronExample.JobRequest(
+                    schedule.getCron(),
+                    "Entrypoint",
+                    "runInternal",
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(input));
 
+            dev.restate.common.Target target =
+                    dev.restate.common.Target.service("CronJobInitiator", "create");
+            ctx.call(dev.restate.common.Request.of(
+                            target,
+                            dev.restate.serde.TypeTag.of(CronExample.JobRequest.class),
+                            dev.restate.serde.TypeTag.of(String.class),
+                            request))
+                    .await();
+            return;
+        }
+
+        runInternal(ctx, input);
+    }
+
+    /** Executes the workflow tasks without considering scheduling. */
+    @dev.restate.sdk.annotation.Workflow
+    public void runInternal(WorkflowContext ctx, Workflow input) {
         var taskItems = input.getDo();
         for (var taskItem : taskItems) {
             Task task = taskItem.getTask();
@@ -25,7 +56,12 @@ public class Entrypoint {
         }
     }
 
+
     public static void main(String[] args) {
-        RestateHttpServer.listen(Endpoint.bind(new Entrypoint()));
+        var builder = Endpoint.builder()
+                .bind(new Entrypoint())
+                .bind(new CronExample.JobInitiator())
+                .bind(new CronExample.Job());
+        RestateHttpServer.listen(builder);
     }
 }


### PR DESCRIPTION
## Summary
- integrate cron scheduling directly in `Entrypoint`
- delete `WorkflowScheduler` service
- schedule workflows without YAML serialization

## Testing
- `./mvnw -DskipTests=false clean install`

------
https://chatgpt.com/codex/tasks/task_e_684c8ed401ec8324a65525a667e4ba0c