### PR TITLE
Improve SwitchTask with default case and add unit tests

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SwitchTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SwitchTaskService.java
@@ -42,11 +42,22 @@ public class SwitchTaskService {
 
     public static void execute(WorkflowContext ctx, SwitchTask task) {
         Pattern p = Pattern.compile("\\.(\\w+)\\s*==\\s*\"([^\"]*)\"");
+        String defaultTarget = null;
         for (SwitchItem aSwitch : task.getSwitch()) {
             SwitchCase switchCase = aSwitch.getSwitchCase();
             String when = switchCase.getWhen();
             boolean match = false;
-            if (when != null) {
+            if (when == null) {
+                FlowDirective then = switchCase.getThen();
+                if (then != null) {
+                    if (then.getFlowDirectiveEnum() != null) {
+                        defaultTarget = then.getFlowDirectiveEnum().name();
+                    } else if (then.getString() != null) {
+                        defaultTarget = then.getString();
+                    }
+                }
+                continue;
+            } else {
                 Matcher m = p.matcher(when);
                 if (m.matches()) {
                     var key = m.group(1);
@@ -66,6 +77,9 @@ public class SwitchTaskService {
                 }
                 return;
             }
+        }
+        if (defaultTarget != null) {
+            ctx.set(NEXT, defaultTarget);
         }
     }
 }

--- a/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/SetTaskServiceTest.java
+++ b/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/SetTaskServiceTest.java
@@ -1,0 +1,75 @@
+package com.amannmalik.workflow.runtime.task;
+
+import dev.restate.sdk.*;
+import dev.restate.sdk.common.HandlerRequest;
+import dev.restate.sdk.common.RetryPolicy;
+import dev.restate.sdk.common.StateKey;
+import dev.restate.common.Request;
+import dev.restate.common.Target;
+import dev.restate.common.Output;
+import dev.restate.serde.TypeTag;
+import io.serverlessworkflow.api.types.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SetTaskServiceTest {
+    static class SimpleAsyncResult<T> implements dev.restate.sdk.endpoint.definition.AsyncResult<T> {
+        private final T value;
+        SimpleAsyncResult(T v) { this.value = v; }
+        @Override public CompletableFuture<T> poll() { return CompletableFuture.completedFuture(value); }
+        @Override public dev.restate.sdk.endpoint.definition.HandlerContext ctx() { return null; }
+        @Override public <U> dev.restate.sdk.endpoint.definition.AsyncResult<U> map(dev.restate.common.function.ThrowingFunction<T, CompletableFuture<U>> f, dev.restate.common.function.ThrowingFunction<dev.restate.sdk.common.TerminalException, CompletableFuture<U>> g) { return new SimpleAsyncResult<>(null); }
+    }
+    static class SimpleDurableFuture<T> extends DurableFuture<T> {
+        private final T value;
+        SimpleDurableFuture(T v) { this.value = v; }
+        @Override protected dev.restate.sdk.endpoint.definition.AsyncResult<T> asyncResult() { return new SimpleAsyncResult<>(value); }
+        @Override protected Executor serviceExecutor() { return Runnable::run; }
+    }
+    static class SimpleInvocationHandle<T> implements InvocationHandle<T> {
+        private final String id;
+        SimpleInvocationHandle(String id) { this.id = id; }
+        @Override public String invocationId() { return id; }
+        @Override public void cancel() { }
+        @Override public DurableFuture<T> attach() { return new SimpleDurableFuture<>(null); }
+        @Override public Output<T> getOutput() { return Output.ready(null); }
+    }
+    static class FakeContext implements WorkflowContext {
+        Map<String,Object> state = new HashMap<>();
+        @Override public HandlerRequest request() { return null; }
+        @Override public <T, R> CallDurableFuture<R> call(Request<T, R> request) { return null; }
+        @Override public <T, R> InvocationHandle<R> send(Request<T, R> request, Duration delay) { return new SimpleInvocationHandle<>("id"); }
+        @Override public <R> InvocationHandle<R> invocationHandle(String id, TypeTag<R> typeTag) { return new SimpleInvocationHandle<>(id); }
+        @Override public DurableFuture<Void> timer(String id, Duration duration) { return new SimpleDurableFuture<>(null); }
+        @Override public <T> DurableFuture<T> runAsync(String name, TypeTag<T> typeTag, RetryPolicy policy, dev.restate.common.function.ThrowingSupplier<T> supplier) { return new SimpleDurableFuture<>(null); }
+        @Override public <T> Awakeable<T> awakeable(TypeTag<T> typeTag) { return null; }
+        @Override public AwakeableHandle awakeableHandle(String id) { return null; }
+        @Override public RestateRandom random() { throw new UnsupportedOperationException(); }
+        @Override public <T> DurablePromise<T> promise(dev.restate.sdk.common.DurablePromiseKey<T> key) { return null; }
+        @Override public <T> DurablePromiseHandle<T> promiseHandle(dev.restate.sdk.common.DurablePromiseKey<T> key) { return null; }
+        @Override public String key() { return "key"; }
+        @Override public <T> Optional<T> get(StateKey<T> key) { return Optional.ofNullable((T)state.get(key.name())); }
+        @Override public Collection<String> stateKeys() { return state.keySet(); }
+        @Override public void clear(StateKey<?> key) { state.remove(key.name()); }
+        @Override public void clearAll() { state.clear(); }
+        @Override public <T> void set(StateKey<T> key, T value) { state.put(key.name(), value); }
+        @Override public void sleep(Duration d) { }
+    }
+
+    @Test
+    void setsVariousTypes() {
+        FakeContext ctx = new FakeContext();
+        SetTask st = new SetTask();
+        io.serverlessworkflow.api.types.Set s = new io.serverlessworkflow.api.types.Set();
+        s.setString("foo");
+        st.setSet(s);
+        SetTaskService.execute(ctx, st);
+        assertEquals("foo", ctx.get(StateKey.of("foo", String.class)).orElse(null));
+    }
+}

--- a/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/SwitchTaskServiceTest.java
+++ b/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/SwitchTaskServiceTest.java
@@ -1,0 +1,104 @@
+package com.amannmalik.workflow.runtime.task;
+
+import dev.restate.sdk.*;
+import dev.restate.sdk.common.HandlerRequest;
+import dev.restate.sdk.common.RetryPolicy;
+import dev.restate.sdk.common.StateKey;
+import dev.restate.common.Request;
+import dev.restate.common.Target;
+import dev.restate.common.Output;
+import dev.restate.serde.TypeTag;
+import io.serverlessworkflow.api.types.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SwitchTaskServiceTest {
+
+    static class SimpleAsyncResult<T> implements dev.restate.sdk.endpoint.definition.AsyncResult<T> {
+        private final T value;
+        SimpleAsyncResult(T v) { this.value = v; }
+        @Override public CompletableFuture<T> poll() { return CompletableFuture.completedFuture(value); }
+        @Override public dev.restate.sdk.endpoint.definition.HandlerContext ctx() { return null; }
+        @Override public <U> dev.restate.sdk.endpoint.definition.AsyncResult<U> map(dev.restate.common.function.ThrowingFunction<T, CompletableFuture<U>> f, dev.restate.common.function.ThrowingFunction<dev.restate.sdk.common.TerminalException, CompletableFuture<U>> g) { return new SimpleAsyncResult<>(null); }
+    }
+
+    static class SimpleDurableFuture<T> extends DurableFuture<T> {
+        private final T value;
+        SimpleDurableFuture(T v) { this.value = v; }
+        @Override protected dev.restate.sdk.endpoint.definition.AsyncResult<T> asyncResult() { return new SimpleAsyncResult<>(value); }
+        @Override protected Executor serviceExecutor() { return Runnable::run; }
+    }
+
+    static class SimpleInvocationHandle<T> implements InvocationHandle<T> {
+        private final String id;
+        SimpleInvocationHandle(String id) { this.id = id; }
+        @Override public String invocationId() { return id; }
+        @Override public void cancel() { }
+        @Override public DurableFuture<T> attach() { return new SimpleDurableFuture<>(null); }
+        @Override public Output<T> getOutput() { return Output.ready(null); }
+    }
+
+    static class FakeContext implements WorkflowContext {
+        Map<String,Object> state = new HashMap<>();
+        @Override public HandlerRequest request() { return null; }
+        @Override public <T, R> CallDurableFuture<R> call(Request<T, R> request) { return null; }
+        @Override public <T, R> InvocationHandle<R> send(Request<T, R> request, Duration delay) { return new SimpleInvocationHandle<>("id"); }
+        @Override public <R> InvocationHandle<R> invocationHandle(String id, TypeTag<R> typeTag) { return new SimpleInvocationHandle<>(id); }
+        @Override public DurableFuture<Void> timer(String id, Duration duration) { return new SimpleDurableFuture<>(null); }
+        @Override public <T> DurableFuture<T> runAsync(String name, TypeTag<T> typeTag, RetryPolicy policy, dev.restate.common.function.ThrowingSupplier<T> supplier) { return new SimpleDurableFuture<>(null); }
+        @Override public <T> Awakeable<T> awakeable(TypeTag<T> typeTag) { return null; }
+        @Override public AwakeableHandle awakeableHandle(String id) { return null; }
+        @Override public RestateRandom random() { throw new UnsupportedOperationException(); }
+        @Override public <T> DurablePromise<T> promise(dev.restate.sdk.common.DurablePromiseKey<T> key) { return null; }
+        @Override public <T> DurablePromiseHandle<T> promiseHandle(dev.restate.sdk.common.DurablePromiseKey<T> key) { return null; }
+        @Override public String key() { return "key"; }
+        @Override public <T> Optional<T> get(StateKey<T> key) { return Optional.ofNullable((T)state.get(key.name())); }
+        @Override public Collection<String> stateKeys() { return state.keySet(); }
+        @Override public void clear(StateKey<?> key) { state.remove(key.name()); }
+        @Override public void clearAll() { state.clear(); }
+        @Override public <T> void set(StateKey<T> key, T value) { state.put(key.name(), value); }
+        @Override public void sleep(Duration d) { }
+    }
+
+    @Test
+    void matchesCase() {
+        FakeContext ctx = new FakeContext();
+        ctx.set(StateKey.of("foo", String.class), "bar");
+        SwitchCase sc = new SwitchCase();
+        sc.setWhen(".foo == \"bar\"");
+        FlowDirective fd = new FlowDirective();
+        fd.setString("NEXT");
+        sc.setThen(fd);
+        SwitchItem si = new SwitchItem("c1", sc);
+        SwitchTask task = new SwitchTask();
+        task.setSwitch(List.of(si));
+        SwitchTaskService.execute(ctx, task);
+        assertEquals("NEXT", ctx.get(SwitchTaskService.NEXT).orElse(null));
+    }
+
+    @Test
+    void usesDefaultCase() {
+        FakeContext ctx = new FakeContext();
+        SwitchCase sc1 = new SwitchCase();
+        sc1.setWhen(".foo == \"bar\"");
+        FlowDirective fd1 = new FlowDirective();
+        fd1.setString("CASE");
+        sc1.setThen(fd1);
+        SwitchCase scDef = new SwitchCase();
+        FlowDirective fdDef = new FlowDirective();
+        fdDef.setString("DEFAULT");
+        scDef.setThen(fdDef);
+        SwitchItem si1 = new SwitchItem("c1", sc1);
+        SwitchItem si2 = new SwitchItem("default", scDef);
+        SwitchTask task = new SwitchTask();
+        task.setSwitch(List.of(si1, si2));
+        SwitchTaskService.execute(ctx, task);
+        assertEquals("DEFAULT", ctx.get(SwitchTaskService.NEXT).orElse(null));
+    }
+}

--- a/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/WaitTaskServiceTest.java
+++ b/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/WaitTaskServiceTest.java
@@ -1,0 +1,90 @@
+package com.amannmalik.workflow.runtime.task;
+
+import dev.restate.sdk.*;
+import dev.restate.sdk.common.HandlerRequest;
+import dev.restate.sdk.common.RetryPolicy;
+import dev.restate.sdk.common.StateKey;
+import dev.restate.common.Request;
+import dev.restate.common.Target;
+import dev.restate.common.Output;
+import dev.restate.serde.TypeTag;
+import io.serverlessworkflow.api.types.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WaitTaskServiceTest {
+    static class SimpleAsyncResult<T> implements dev.restate.sdk.endpoint.definition.AsyncResult<T> {
+        private final T value;
+        SimpleAsyncResult(T v) { this.value = v; }
+        @Override public CompletableFuture<T> poll() { return CompletableFuture.completedFuture(value); }
+        @Override public dev.restate.sdk.endpoint.definition.HandlerContext ctx() { return null; }
+        @Override public <U> dev.restate.sdk.endpoint.definition.AsyncResult<U> map(dev.restate.common.function.ThrowingFunction<T, CompletableFuture<U>> f, dev.restate.common.function.ThrowingFunction<dev.restate.sdk.common.TerminalException, CompletableFuture<U>> g) { return new SimpleAsyncResult<>(null); }
+    }
+    static class SimpleDurableFuture<T> extends DurableFuture<T> {
+        private final T value;
+        SimpleDurableFuture(T v) { this.value = v; }
+        @Override protected dev.restate.sdk.endpoint.definition.AsyncResult<T> asyncResult() { return new SimpleAsyncResult<>(value); }
+        @Override protected Executor serviceExecutor() { return Runnable::run; }
+    }
+    static class SimpleInvocationHandle<T> implements InvocationHandle<T> {
+        private final String id;
+        SimpleInvocationHandle(String id) { this.id = id; }
+        @Override public String invocationId() { return id; }
+        @Override public void cancel() { }
+        @Override public DurableFuture<T> attach() { return new SimpleDurableFuture<>(null); }
+        @Override public Output<T> getOutput() { return Output.ready(null); }
+    }
+    static class FakeContext implements WorkflowContext {
+        Map<String,Object> state = new HashMap<>();
+        List<Duration> sleeps = new ArrayList<>();
+        @Override public HandlerRequest request() { return null; }
+        @Override public <T, R> CallDurableFuture<R> call(Request<T, R> request) { return null; }
+        @Override public <T, R> InvocationHandle<R> send(Request<T, R> request, Duration delay) { return new SimpleInvocationHandle<>("id"); }
+        @Override public <R> InvocationHandle<R> invocationHandle(String id, TypeTag<R> typeTag) { return new SimpleInvocationHandle<>(id); }
+        @Override public DurableFuture<Void> timer(String id, Duration duration) { return new SimpleDurableFuture<>(null); }
+        @Override public <T> DurableFuture<T> runAsync(String name, TypeTag<T> typeTag, RetryPolicy policy, dev.restate.common.function.ThrowingSupplier<T> supplier) { return new SimpleDurableFuture<>(null); }
+        @Override public <T> Awakeable<T> awakeable(TypeTag<T> typeTag) { return null; }
+        @Override public AwakeableHandle awakeableHandle(String id) { return null; }
+        @Override public RestateRandom random() { throw new UnsupportedOperationException(); }
+        @Override public <T> DurablePromise<T> promise(dev.restate.sdk.common.DurablePromiseKey<T> key) { return null; }
+        @Override public <T> DurablePromiseHandle<T> promiseHandle(dev.restate.sdk.common.DurablePromiseKey<T> key) { return null; }
+        @Override public String key() { return "key"; }
+        @Override public <T> Optional<T> get(StateKey<T> key) { return Optional.ofNullable((T)state.get(key.name())); }
+        @Override public Collection<String> stateKeys() { return state.keySet(); }
+        @Override public void clear(StateKey<?> key) { state.remove(key.name()); }
+        @Override public void clearAll() { state.clear(); }
+        @Override public <T> void set(StateKey<T> key, T value) { state.put(key.name(), value); }
+        @Override public void sleep(Duration d) { sleeps.add(d); }
+    }
+
+    @Test
+    void waitWithDurationExpression() {
+        FakeContext ctx = new FakeContext();
+        TimeoutAfter ta = new TimeoutAfter();
+        ta.setDurationExpression("PT2S");
+        WaitTask wt = new WaitTask();
+        wt.setWait(ta);
+        WaitTaskService.execute(ctx, wt);
+        assertEquals(Duration.parse("PT2S"), ctx.sleeps.get(0));
+    }
+
+    @Test
+    void waitWithDurationInline() {
+        FakeContext ctx = new FakeContext();
+        TimeoutAfter ta = new TimeoutAfter();
+        DurationInline di = new DurationInline();
+        di.setSeconds(1);
+        di.setMilliseconds(500);
+        ta.setDurationInline(di);
+        WaitTask wt = new WaitTask();
+        wt.setWait(ta);
+        WaitTaskService.execute(ctx, wt);
+        assertEquals(Duration.ofSeconds(1).plusMillis(500), ctx.sleeps.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add default case support in `SwitchTaskService`
- increase test coverage with new unit tests for Switch, Wait, and Set tasks

## Testing
- `./mvnw clean test`

------
https://chatgpt.com/codex/tasks/task_e_684e124dc5fc8324a9dc7a476687e5ad