### PR TITLE
Refactor service definition setup

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/DefinitionHelper.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/DefinitionHelper.java
@@ -1,0 +1,82 @@
+package com.amannmalik.workflow.runtime;
+
+import dev.restate.common.function.ThrowingBiConsumer;
+import dev.restate.sdk.HandlerRunner;
+import dev.restate.sdk.Context;
+import dev.restate.sdk.WorkflowContext;
+import dev.restate.sdk.endpoint.definition.HandlerDefinition;
+import dev.restate.sdk.endpoint.definition.HandlerType;
+import dev.restate.sdk.endpoint.definition.ServiceDefinition;
+import dev.restate.sdk.endpoint.definition.ServiceType;
+import dev.restate.serde.Serde;
+import dev.restate.serde.jackson.JacksonSerdeFactory;
+import dev.restate.serde.jackson.JacksonSerdes;
+
+import java.util.List;
+
+/** Utility helpers for building {@link ServiceDefinition} constants. */
+public final class DefinitionHelper {
+
+    private DefinitionHelper() {
+    }
+
+    /**
+     * Build a service definition for a task service with a single shared handler named "execute".
+     */
+    public static <REQ> ServiceDefinition taskService(
+            Class<?> serviceClass,
+            Class<REQ> requestClass,
+            ThrowingBiConsumer<WorkflowContext, REQ> handler) {
+        return singleVoidHandlerService(
+                serviceClass,
+                ServiceType.SERVICE,
+                "execute",
+                HandlerType.SHARED,
+                requestClass,
+                handler
+        );
+    }
+
+    /**
+     * Generic helper to create a service definition with a single void-returning handler.
+     */
+    public static <CTX extends Context, REQ> ServiceDefinition singleVoidHandlerService(
+            Class<?> serviceClass,
+            ServiceType serviceType,
+            String handlerName,
+            HandlerType handlerType,
+            Class<REQ> requestClass,
+            ThrowingBiConsumer<CTX, REQ> handler) {
+        return singleVoidHandlerService(
+                serviceClass.getSimpleName(),
+                serviceType,
+                handlerName,
+                handlerType,
+                requestClass,
+                handler
+        );
+    }
+
+    /** Variant allowing a custom service name. */
+    public static <CTX extends Context, REQ> ServiceDefinition singleVoidHandlerService(
+            String serviceName,
+            ServiceType serviceType,
+            String handlerName,
+            HandlerType handlerType,
+            Class<REQ> requestClass,
+            ThrowingBiConsumer<CTX, REQ> handler) {
+        return ServiceDefinition.of(
+                serviceName,
+                serviceType,
+                List.of(
+                        HandlerDefinition.of(
+                                handlerName,
+                                handlerType,
+                                JacksonSerdes.of(requestClass),
+                                Serde.VOID,
+                                HandlerRunner.of(handler, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
+                        )
+                )
+        );
+    }
+}

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/cron/CronJobInitiator.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/cron/CronJobInitiator.java
@@ -1,32 +1,23 @@
 package com.amannmalik.workflow.runtime.cron;
 
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import com.amannmalik.workflow.runtime.Services;
 import dev.restate.sdk.Context;
-import dev.restate.sdk.HandlerRunner;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
-
-import java.util.List;
+import dev.restate.sdk.endpoint.definition.HandlerType;
+import com.amannmalik.workflow.runtime.cron.CronJobRequest;
+import com.amannmalik.workflow.runtime.cron.CronJobInfo;
 
 public class CronJobInitiator {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.singleVoidHandlerService(
             "CronJobInitiator",
             ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "create",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(CronJobRequest.class),
-                            JacksonSerdes.of(String.class),
-                            HandlerRunner.of(CronJobInitiator::create, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+            "create",
+            HandlerType.SHARED,
+            CronJobRequest.class,
+            CronJobInitiator::create
     );
 
     public static String create(Context ctx, CronJobRequest request) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/EmitTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/EmitTaskService.java
@@ -1,15 +1,9 @@
 package com.amannmalik.workflow.runtime.task;
 
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import com.amannmalik.workflow.runtime.Services;
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
 import io.serverlessworkflow.api.types.EmitEventDefinition;
 import io.serverlessworkflow.api.types.EmitTask;
 import io.serverlessworkflow.api.types.EmitTaskConfiguration;
@@ -22,18 +16,10 @@ import java.util.List;
 
 public class EmitTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "EmitTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(EmitTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(EmitTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            EmitTaskService.class,
+            EmitTask.class,
+            EmitTaskService::execute
     );
 
     private static final Logger log = LoggerFactory.getLogger(EmitTaskService.class);

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/ForkTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/ForkTaskService.java
@@ -1,17 +1,12 @@
 package com.amannmalik.workflow.runtime.task;
 
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.DurableFuture;
 import dev.restate.sdk.common.RetryPolicy;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
 import dev.restate.serde.TypeTag;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
 import dev.restate.serde.jackson.JacksonSerdes;
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.ForkTask;
 import io.serverlessworkflow.api.types.TaskItem;
 
@@ -19,18 +14,10 @@ import java.util.List;
 
 public class ForkTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "ForkTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(ForkTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(ForkTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            ForkTaskService.class,
+            ForkTask.class,
+            ForkTaskService::execute
     );
 
     public static void execute(WorkflowContext ctx, ForkTask task) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/ListenTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/ListenTaskService.java
@@ -1,15 +1,9 @@
 package com.amannmalik.workflow.runtime.task;
 
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import com.amannmalik.workflow.runtime.Services;
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
 import io.serverlessworkflow.api.types.EventFilter;
 import io.serverlessworkflow.api.types.ListenTask;
 import io.serverlessworkflow.api.types.ListenTaskConfiguration;
@@ -25,18 +19,10 @@ import java.util.List;
  */
 public class ListenTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "ListenTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(ListenTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(ListenTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            ListenTaskService.class,
+            ListenTask.class,
+            ListenTaskService::execute
     );
 
     private static final Logger log = LoggerFactory.getLogger(ListenTaskService.class);

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SetTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SetTaskService.java
@@ -1,35 +1,19 @@
 package com.amannmalik.workflow.runtime.task;
 
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.common.StateKey;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.SetTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-
 public class SetTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "SetTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(SetTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(SetTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            SetTaskService.class,
+            SetTask.class,
+            SetTaskService::execute
     );
 
     private static final Logger log = LoggerFactory.getLogger(SetTaskService.class);

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SwitchTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SwitchTaskService.java
@@ -1,15 +1,9 @@
 package com.amannmalik.workflow.runtime.task;
 
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.common.StateKey;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.FlowDirective;
 import io.serverlessworkflow.api.types.SwitchCase;
 import io.serverlessworkflow.api.types.SwitchItem;
@@ -23,18 +17,10 @@ import java.util.regex.Pattern;
 
 public class SwitchTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "SwitchTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(SwitchTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(SwitchTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            SwitchTaskService.class,
+            SwitchTask.class,
+            SwitchTaskService::execute
     );
 
     private static final Logger log = LoggerFactory.getLogger(SwitchTaskService.class);

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/TryTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/TryTaskService.java
@@ -1,14 +1,8 @@
 package com.amannmalik.workflow.runtime.task;
 
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.TryTask;
 import io.serverlessworkflow.api.types.TryTaskCatch;
@@ -17,18 +11,10 @@ import java.util.List;
 
 public class TryTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "TryTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(TryTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(TryTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            TryTaskService.class,
+            TryTask.class,
+            TryTaskService::execute
     );
 
     public static void execute(WorkflowContext ctx, TryTask task) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WaitTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WaitTaskService.java
@@ -1,33 +1,18 @@
 package com.amannmalik.workflow.runtime.task;
 
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.WaitTask;
 
 import java.time.Duration;
-import java.util.List;
 
 public class WaitTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "WaitTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(WaitTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(WaitTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            WaitTaskService.class,
+            WaitTask.class,
+            WaitTaskService::execute
     );
 
     public static void execute(WorkflowContext ctx, WaitTask task) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WorkflowTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WorkflowTaskService.java
@@ -1,17 +1,13 @@
 package com.amannmalik.workflow.runtime.task;
 
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import com.amannmalik.workflow.runtime.Services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.restate.sdk.Context;
-import dev.restate.sdk.HandlerRunner;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
+import dev.restate.sdk.endpoint.definition.HandlerType;
 import io.serverlessworkflow.api.types.CallTask;
 import io.serverlessworkflow.api.types.DoTask;
 import io.serverlessworkflow.api.types.EmitTask;
@@ -33,9 +29,14 @@ import java.util.List;
 
 public class WorkflowTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(MethodHandles.lookup().lookupClass().getCanonicalName(), ServiceType.SERVICE, List.of(
-            HandlerDefinition.of("execute", HandlerType.SHARED, JacksonSerdes.of(Task.class), Serde.VOID, HandlerRunner.of(WorkflowTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT))
-    ));
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.singleVoidHandlerService(
+            MethodHandles.lookup().lookupClass().getCanonicalName(),
+            ServiceType.SERVICE,
+            "execute",
+            HandlerType.SHARED,
+            Task.class,
+            WorkflowTaskService::execute
+    );
 
     private static final Logger log = LoggerFactory.getLogger(WorkflowTaskService.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/CallTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/CallTaskService.java
@@ -3,16 +3,10 @@ package com.amannmalik.workflow.runtime.task.call;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.common.StateKey;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.CallAsyncAPI;
 import io.serverlessworkflow.api.types.CallFunction;
 import io.serverlessworkflow.api.types.CallGRPC;
@@ -37,18 +31,10 @@ import java.util.regex.Pattern;
 
 public class CallTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "CallTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(CallTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(CallTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            CallTaskService.class,
+            CallTask.class,
+            CallTaskService::execute
     );
 
     private static final Logger log = LoggerFactory.getLogger(CallTaskService.class);

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/RunTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/RunTaskService.java
@@ -1,16 +1,10 @@
 package com.amannmalik.workflow.runtime.task.run;
 
+import com.amannmalik.workflow.runtime.DefinitionHelper;
 import com.amannmalik.workflow.runtime.WorkflowRegistry;
 import com.amannmalik.workflow.runtime.WorkflowRunner;
-import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.WorkflowContext;
-import dev.restate.sdk.endpoint.definition.HandlerDefinition;
-import dev.restate.sdk.endpoint.definition.HandlerType;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
-import dev.restate.sdk.endpoint.definition.ServiceType;
-import dev.restate.serde.Serde;
-import dev.restate.serde.jackson.JacksonSerdeFactory;
-import dev.restate.serde.jackson.JacksonSerdes;
 import io.serverlessworkflow.api.types.RunContainer;
 import io.serverlessworkflow.api.types.RunScript;
 import io.serverlessworkflow.api.types.RunShell;
@@ -25,18 +19,10 @@ import java.util.List;
 
 public class RunTaskService {
 
-    public static final ServiceDefinition DEFINITION = ServiceDefinition.of(
-            "RunTaskService",
-            ServiceType.SERVICE,
-            List.of(
-                    HandlerDefinition.of(
-                            "execute",
-                            HandlerType.SHARED,
-                            JacksonSerdes.of(RunTask.class),
-                            Serde.VOID,
-                            HandlerRunner.of(RunTaskService::execute, JacksonSerdeFactory.DEFAULT, HandlerRunner.Options.DEFAULT)
-                    )
-            )
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            RunTaskService.class,
+            RunTask.class,
+            RunTaskService::execute
     );
 
     private static final Logger log = LoggerFactory.getLogger(RunTaskService.class);


### PR DESCRIPTION
## Summary
- add `DefinitionHelper` utility to build `ServiceDefinition` constants
- refactor task services and `CronJobInitiator` to use the helper
- keep behavior by providing overloaded helper for custom names

## Testing
- `./mvnw -pl durable-workflow-runtime -am clean test`

------
https://chatgpt.com/codex/tasks/task_e_684e17426ec8832490f075c44de67752