### PR TITLE
Fix Set task handling

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SetTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/SetTaskService.java
@@ -20,15 +20,27 @@ public class SetTaskService {
 
     public static void execute(WorkflowContext ctx, SetTask task) {
         var s = task.getSet();
+        var config = s.getSetTaskConfiguration();
+        if (config != null) {
+            config.getAdditionalProperties().forEach((k, v) -> setValue(ctx, k, v));
+            return;
+        }
+
         var k = s.getString();
-        var v = s.get();
+        if (k != null) {
+            // Treat single string as key name and value
+            ctx.set(StateKey.of(k, String.class), k);
+        }
+    }
+
+    private static void setValue(WorkflowContext ctx, String k, Object v) {
         switch (v) {
             case String sv -> ctx.set(StateKey.of(k, String.class), sv);
             case Long sl -> ctx.set(StateKey.of(k, Long.class), sl);
             case Integer si -> ctx.set(StateKey.of(k, Integer.class), si);
             case Double sd -> ctx.set(StateKey.of(k, Double.class), sd);
             case Boolean sb -> ctx.set(StateKey.of(k, Boolean.class), sb);
-            default -> log.warn("Unsupported set value type: {}", v.getClass());
+            default -> ctx.set(StateKey.of(k, Object.class), v);
         }
     }
 }

--- a/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/SetTaskServiceTest.java
+++ b/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/task/SetTaskServiceTest.java
@@ -72,4 +72,19 @@ class SetTaskServiceTest {
         SetTaskService.execute(ctx, st);
         assertEquals("foo", ctx.get(StateKey.of("foo", String.class)).orElse(null));
     }
+
+    @Test
+    void setsMapValues() {
+        FakeContext ctx = new FakeContext();
+        SetTask st = new SetTask();
+        io.serverlessworkflow.api.types.Set s = new io.serverlessworkflow.api.types.Set();
+        SetTaskConfiguration cfg = new SetTaskConfiguration();
+        cfg.setAdditionalProperty("a", "b");
+        cfg.setAdditionalProperty("n", 1);
+        s.setSetTaskConfiguration(cfg);
+        st.setSet(s);
+        SetTaskService.execute(ctx, st);
+        assertEquals("b", ctx.get(StateKey.of("a", String.class)).orElse(null));
+        assertEquals(1, ctx.get(StateKey.of("n", Integer.class)).orElse(null));
+    }
 }


### PR DESCRIPTION
## Summary
- support map values in `SetTaskService`
- add tests for map behavior

## Testing
- `./mvnw test -DtrimStackTrace=false`

------
https://chatgpt.com/codex/tasks/task_e_684e2262e33483249e193beb47f2f454