### PR TITLE
Implement raise and try/catch handling

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/RaiseTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/RaiseTaskService.java
@@ -1,0 +1,34 @@
+package com.amannmalik.workflow.runtime.task;
+
+import com.amannmalik.workflow.runtime.DefinitionHelper;
+import dev.restate.sdk.WorkflowContext;
+import dev.restate.sdk.endpoint.definition.ServiceDefinition;
+import io.serverlessworkflow.api.types.Error;
+import io.serverlessworkflow.api.types.RaiseTask;
+import io.serverlessworkflow.api.types.RaiseTaskConfiguration;
+import io.serverlessworkflow.api.types.RaiseTaskError;
+
+/** Service executing the raise task as defined in the DSL. */
+public class RaiseTaskService {
+
+    public static final ServiceDefinition DEFINITION = DefinitionHelper.taskService(
+            RaiseTaskService.class,
+            RaiseTask.class,
+            RaiseTaskService::execute
+    );
+
+    public static void execute(WorkflowContext ctx, RaiseTask task) {
+        RaiseTaskConfiguration rc = task.getRaise();
+        if (rc == null || rc.getError() == null) {
+            return;
+        }
+        RaiseTaskError rte = rc.getError();
+        Object val = rte.get();
+        if (val instanceof Error err) {
+            throw new WorkflowErrorException(err);
+        } else {
+            // References to reusable errors not yet supported
+            throw new RuntimeException("Referenced errors not supported");
+        }
+    }
+}

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/TryTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/TryTaskService.java
@@ -1,11 +1,16 @@
 package com.amannmalik.workflow.runtime.task;
 
 import dev.restate.sdk.WorkflowContext;
+import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import com.amannmalik.workflow.runtime.DefinitionHelper;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.TryTask;
 import io.serverlessworkflow.api.types.TryTaskCatch;
+import io.serverlessworkflow.api.types.ErrorFilter;
+import io.serverlessworkflow.api.types.Error;
+
+import com.amannmalik.workflow.runtime.task.WorkflowErrorException;
 
 import java.util.List;
 
@@ -25,13 +30,63 @@ public class TryTaskService {
                 new WorkflowTaskService().execute(ctx, ti.getTask());
             }
         } catch (Exception e) {
-            if (aCatch != null) {
-                for (var ti : aCatch.getDo()) {
-                    new WorkflowTaskService().execute(ctx, ti.getTask());
+            if (aCatch == null) {
+                throw e;
+            }
+
+            if (e instanceof WorkflowErrorException we) {
+                if (!matches(aCatch.getErrors() == null ? null : aCatch.getErrors().getWith(), we.getError())) {
+                    throw e;
                 }
+                String var = aCatch.getAs() == null ? "error" : aCatch.getAs();
+                ctx.set(StateKey.of(var, Error.class), we.getError());
             } else {
                 throw e;
             }
+
+            if (aCatch.getDo() != null) {
+                for (var ti : aCatch.getDo()) {
+                    new WorkflowTaskService().execute(ctx, ti.getTask());
+                }
+            }
         }
+    }
+
+    private static boolean matches(ErrorFilter filter, Error err) {
+        if (filter == null) {
+            return true;
+        }
+        if (filter.getType() != null) {
+            var et = err.getType();
+            String t = et == null ? null : et.getLiteralErrorType().toString();
+            if (!filter.getType().equals(t)) {
+                return false;
+            }
+        }
+        if (filter.getStatus() != 0 && filter.getStatus() != err.getStatus()) {
+            return false;
+        }
+        if (filter.getInstance() != null) {
+            var inst = err.getInstance();
+            String i = inst == null ? null : inst.getLiteralErrorInstance();
+            if (!filter.getInstance().equals(i)) {
+                return false;
+            }
+        }
+        if (filter.getTitle() != null) {
+            var tt = err.getTitle();
+            String t = tt == null ? null : tt.getLiteralErrorTitle();
+            if (!filter.getTitle().equals(t)) {
+                return false;
+            }
+        }
+        if (filter.getDetails() != null) {
+            var dt = err.getDetail();
+            String d = dt == null ? null : dt.getLiteralErrorDetails();
+            if (!filter.getDetails().equals(d)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WorkflowErrorException.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WorkflowErrorException.java
@@ -1,0 +1,20 @@
+package com.amannmalik.workflow.runtime.task;
+
+import io.serverlessworkflow.api.types.Error;
+
+/** Exception thrown when a workflow error is raised. */
+public class WorkflowErrorException extends RuntimeException {
+
+    private final Error error;
+
+    public WorkflowErrorException(Error error) {
+        super(error != null && error.getTitle() != null
+                ? error.getTitle().getLiteralErrorTitle()
+                : null);
+        this.error = error;
+    }
+
+    public Error getError() {
+        return error;
+    }
+}

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WorkflowTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WorkflowTaskService.java
@@ -50,21 +50,13 @@ public class WorkflowTaskService {
             case EmitTask x -> await(Services.callService(ctx, "EmitTaskService", "execute", x, Void.class));
             case ForTask x -> x.getDo().forEach(t -> execute(ctx, t.getTask()));
             case ListenTask x -> await(Services.callService(ctx, "ListenTaskService", "execute", x, Void.class));
-            case RaiseTask x -> logRaise(x);
+            case RaiseTask x -> await(Services.callService(ctx, "RaiseTaskService", "execute", x, Void.class));
             case RunTask x -> await(Services.callService(ctx, "RunTaskService", "execute", x, Void.class));
             case SetTask x -> await(Services.callService(ctx, "SetTaskService", "execute", x, Void.class));
             case SwitchTask x -> await(Services.callService(ctx, "SwitchTaskService", "execute", x, Void.class));
             case TryTask x -> await(Services.callService(ctx, "TryTaskService", "execute", x, Void.class));
             case WaitTask x -> await(Services.callService(ctx, "WaitTaskService", "execute", x, Void.class));
             default -> throw new UnsupportedOperationException("Unexpected task: " + task.get());
-        }
-    }
-
-    private static void logRaise(RaiseTask x) {
-        try {
-            log.warn("Raise event: {}", MAPPER.writeValueAsString(x.getRaise()));
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException(e);
         }
     }
 


### PR DESCRIPTION
## Summary
- hook raise tasks into the task dispatcher
- add `RaiseTaskService` to throw workflow errors
- support error filtering and variable binding for try/catch
- expose `WorkflowErrorException` used to propagate raised errors

## Testing
- `./mvnw -DskipTests install`
- `./mvnw clean install`


------
https://chatgpt.com/codex/tasks/task_e_684eecfc716083249363172f9f12408e