### PR TITLE
Avoid instantiating task services

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/ForkTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/ForkTaskService.java
@@ -7,6 +7,7 @@ import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import dev.restate.serde.TypeTag;
 import dev.restate.serde.jackson.JacksonSerdes;
 import com.amannmalik.workflow.runtime.DefinitionHelper;
+import com.amannmalik.workflow.runtime.Services;
 import io.serverlessworkflow.api.types.ForkTask;
 import io.serverlessworkflow.api.types.TaskItem;
 
@@ -27,7 +28,7 @@ public class ForkTaskService {
         for (TaskItem item : fork.getBranches()) {
             String name = "branch-" + (i++);
             futures.add(ctx.runAsync(name, TypeTag.of(Void.class), RetryPolicy.defaultPolicy(), () -> {
-                new WorkflowTaskService().execute(ctx, item.getTask());
+                Services.callService(ctx, "WorkflowTaskService", "execute", item.getTask(), Void.class).await();
                 return null;
             }));
         }

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/TryTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/TryTaskService.java
@@ -4,6 +4,7 @@ import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import com.amannmalik.workflow.runtime.DefinitionHelper;
+import com.amannmalik.workflow.runtime.Services;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.api.types.TryTask;
 import io.serverlessworkflow.api.types.TryTaskCatch;
@@ -27,7 +28,7 @@ public class TryTaskService {
         TryTaskCatch aCatch = task.getCatch();
         try {
             for (var ti : aTry) {
-                new WorkflowTaskService().execute(ctx, ti.getTask());
+                Services.callService(ctx, "WorkflowTaskService", "execute", ti.getTask(), Void.class).await();
             }
         } catch (Exception e) {
             if (aCatch == null) {
@@ -46,7 +47,7 @@ public class TryTaskService {
 
             if (aCatch.getDo() != null) {
                 for (var ti : aCatch.getDo()) {
-                    new WorkflowTaskService().execute(ctx, ti.getTask());
+                    Services.callService(ctx, "WorkflowTaskService", "execute", ti.getTask(), Void.class).await();
                 }
             }
         }

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/RunTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/RunTaskService.java
@@ -3,6 +3,7 @@ package com.amannmalik.workflow.runtime.task.run;
 import com.amannmalik.workflow.runtime.DefinitionHelper;
 import com.amannmalik.workflow.runtime.WorkflowRegistry;
 import com.amannmalik.workflow.runtime.WorkflowRunner;
+import com.amannmalik.workflow.runtime.Services;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import io.serverlessworkflow.api.types.RunContainer;
@@ -68,7 +69,7 @@ public class RunTaskService {
             log.warn("Sub-workflow not found: {}:{}:{}", cfg.getNamespace(), cfg.getName(), cfg.getVersion());
             return;
         }
-        new WorkflowRunner().runInternal(ctx, wf);
+        Services.callService(ctx, "WorkflowRunner", "runInternal", wf, Void.class).await();
     }
 
 }

--- a/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/EnterpriseWorkflowE2ETest.java
+++ b/durable-workflow-runtime/src/test/java/com/amannmalik/workflow/runtime/EnterpriseWorkflowE2ETest.java
@@ -10,6 +10,8 @@ import dev.restate.common.Output;
 import dev.restate.common.Request;
 import dev.restate.common.Target;
 import dev.restate.sdk.*;
+import dev.restate.sdk.endpoint.definition.HandlerContext;
+import dev.restate.sdk.endpoint.definition.AsyncResult;
 import dev.restate.sdk.common.HandlerRequest;
 import dev.restate.sdk.common.RetryPolicy;
 import dev.restate.sdk.common.StateKey;
@@ -70,22 +72,37 @@ class EnterpriseWorkflowE2ETest {
             Object req = request.getRequest();
             if ("WaitTaskService".equals(svc) && "execute".equals(m)) {
                 WaitTaskService.execute(this, (WaitTask) req);
+                return completed();
             } else if ("ForkTaskService".equals(svc) && "execute".equals(m)) {
                 ForkTaskService.execute(this, (ForkTask) req);
+                return completed();
             } else if ("RunTaskService".equals(svc) && "execute".equals(m)) {
                 RunTaskService.execute(this, (RunTask) req);
+                return completed();
             } else if ("SetTaskService".equals(svc) && "execute".equals(m)) {
                 SetTaskService.execute(this, (SetTask) req);
+                return completed();
             } else if ("SwitchTaskService".equals(svc) && "execute".equals(m)) {
                 SwitchTaskService.execute(this, (SwitchTask) req);
+                return completed();
             } else if ("CallTaskService".equals(svc) && "execute".equals(m)) {
                 CallTaskService.execute(this, (CallTask) req);
+                return completed();
             } else if ("ListenTaskService".equals(svc) && "execute".equals(m)) {
                 ListenTaskService.execute(this, (ListenTask) req);
+                return completed();
             } else if ("EmitTaskService".equals(svc) && "execute".equals(m)) {
                 EmitTaskService.execute(this, (EmitTask) req);
+                return completed();
             } else if ("TryTaskService".equals(svc) && "execute".equals(m)) {
                 TryTaskService.execute(this, (TryTask) req);
+                return completed();
+            } else if ("WorkflowTaskService".equals(svc) && "execute".equals(m)) {
+                WorkflowTaskService.execute(this, (Task) req);
+                return completed();
+            } else if ("WorkflowRunner".equals(svc) && "runInternal".equals(m)) {
+                WorkflowRunner.runInternal(this, (Workflow) req);
+                return completed();
             }
             return null;
         }
@@ -105,6 +122,24 @@ class EnterpriseWorkflowE2ETest {
         @Override public void clearAll() { state.clear(); }
         @Override public <T> void set(StateKey<T> key, T value) { state.put(key.name(), value); }
         @Override public void sleep(Duration d) { sleeps.add(d); }
+
+        private <R> CallDurableFuture<R> completed() {
+            try {
+                var ctor = CallDurableFuture.class.getDeclaredConstructor(
+                        HandlerContext.class,
+                        AsyncResult.class,
+                        DurableFuture.class
+                );
+                ctor.setAccessible(true);
+                return (CallDurableFuture<R>) ctor.newInstance(
+                        null,
+                        new SimpleAsyncResult<>(null),
+                        new SimpleDurableFuture<>("id")
+                );
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
## Summary
- invoke all runtime services through `Services.callService`
- handle `WorkflowTaskService` and `WorkflowRunner` calls in tests

## Testing
- `./mvnw -DskipTests=false test`

------
https://chatgpt.com/codex/tasks/task_e_684eef93c36c8324a4fb223dedcaf443