### PR TITLE
Refactor Java code with JDK 21 features

### DIFF
--- a/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/model/DurableWorkflowSpec.java
+++ b/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/model/DurableWorkflowSpec.java
@@ -2,14 +2,4 @@ package com.amannmalik.workflow.operator.model;
 
 import io.serverlessworkflow.api.types.Workflow;
 
-public class DurableWorkflowSpec {
-    private Workflow definition;
-
-    public Workflow getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(Workflow definition) {
-        this.definition = definition;
-    }
-}
+public record DurableWorkflowSpec(Workflow definition) {}

--- a/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/model/DurableWorkflowStatus.java
+++ b/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/model/DurableWorkflowStatus.java
@@ -1,4 +1,3 @@
 package com.amannmalik.workflow.operator.model;
 
-public class DurableWorkflowStatus {
-}
+public record DurableWorkflowStatus() {}

--- a/durable-workflow-operator/src/test/java/com/amannmalik/workflow/operator/EndToEndTest.java
+++ b/durable-workflow-operator/src/test/java/com/amannmalik/workflow/operator/EndToEndTest.java
@@ -27,10 +27,14 @@ public class EndToEndTest {
     @Test
     void testNewDeployment() throws Exception {
         var servlet = new WorkflowServlet(client);
-        String yaml = "apiVersion: amannmalik.com/v1alpha1\n" +
-                "kind: DurableWorkflow\n" +
-                "metadata:\n  name: wf\n" +
-                "spec:\n  definition: {}\n";
+        String yaml = """
+                apiVersion: amannmalik.com/v1alpha1
+                kind: DurableWorkflow
+                metadata:
+                  name: wf
+                spec:
+                  definition: {}
+                """;
         HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
         ServletInputStream sis = new ServletInputStream() {
             private final java.io.InputStream in = new java.io.ByteArrayInputStream(yaml.getBytes(java.nio.charset.StandardCharsets.UTF_8));

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WaitTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/WaitTaskService.java
@@ -13,21 +13,17 @@ public class WaitTaskService {
             DefinitionHelper.taskService(WaitTaskService.class, WaitTask.class, WaitTaskService::execute);
 
     public static void execute(WorkflowContext ctx, WaitTask task) {
-        var wtc = task.getWait();
-        var de = wtc.getDurationExpression();
-        Duration resolvedDuration = Duration.ZERO;
-        if (de != null) {
-            resolvedDuration = Duration.parse(de);
-        } else {
-            var duri = wtc.getDurationInline();
-            resolvedDuration =
-                    resolvedDuration
-                            .plusDays(duri.getDays())
-                            .plusHours(duri.getHours())
-                            .plusMinutes(duri.getMinutes())
-                            .plusSeconds(duri.getSeconds())
-                            .plusMillis(duri.getMilliseconds());
-        }
-        ctx.sleep(resolvedDuration);
+        var w = task.getWait();
+        var dur = w.getDurationExpression();
+        var i = w.getDurationInline();
+        Duration d = (dur != null)
+                ? Duration.parse(dur)
+                : Duration.ZERO
+                        .plusDays(i.getDays())
+                        .plusHours(i.getHours())
+                        .plusMinutes(i.getMinutes())
+                        .plusSeconds(i.getSeconds())
+                        .plusMillis(i.getMilliseconds());
+        ctx.sleep(d);
     }
 }

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/RunTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/RunTaskService.java
@@ -1,11 +1,7 @@
 package com.amannmalik.workflow.runtime.task.run;
 
 import com.amannmalik.workflow.runtime.DefinitionHelper;
-import com.amannmalik.workflow.runtime.task.run.handler.ContainerRunHandler;
-import com.amannmalik.workflow.runtime.task.run.handler.RunHandler;
-import com.amannmalik.workflow.runtime.task.run.handler.ScriptRunHandler;
-import com.amannmalik.workflow.runtime.task.run.handler.ShellRunHandler;
-import com.amannmalik.workflow.runtime.task.run.handler.WorkflowRunHandler;
+import com.amannmalik.workflow.runtime.task.run.handler.*;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.endpoint.definition.ServiceDefinition;
 import io.serverlessworkflow.api.types.RunContainer;
@@ -17,30 +13,20 @@ import io.serverlessworkflow.api.types.RunWorkflow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 public class RunTaskService {
 
     private static final Logger log = LoggerFactory.getLogger(RunTaskService.class);
     public static final ServiceDefinition DEFINITION =
             DefinitionHelper.taskService(RunTaskService.class, RunTask.class, RunTaskService::execute);
 
-    private static final Map<Class<?>, RunHandler<?>> HANDLERS =
-            Map.of(
-                    RunContainer.class, new ContainerRunHandler(),
-                    RunScript.class, new ScriptRunHandler(),
-                    RunShell.class, new ShellRunHandler(),
-                    RunWorkflow.class, new WorkflowRunHandler());
-
-    @SuppressWarnings("unchecked")
     public static void execute(WorkflowContext ctx, RunTask task) {
-        RunTaskConfigurationUnion run = task.getRun();
-        Object obj = run.get();
-        RunHandler<Object> handler = (RunHandler<Object>) HANDLERS.get(obj.getClass());
-        if (handler != null) {
-            handler.handle(ctx, obj);
-        } else {
-            throw new UnsupportedOperationException();
+        Object obj = task.getRun().get();
+        switch (obj) {
+            case RunContainer r -> new ContainerRunHandler().handle(ctx, r);
+            case RunScript r -> new ScriptRunHandler().handle(ctx, r);
+            case RunShell r -> new ShellRunHandler().handle(ctx, r);
+            case RunWorkflow r -> new WorkflowRunHandler().handle(ctx, r);
+            default -> throw new UnsupportedOperationException();
         }
     }
 }

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/ContainerRunHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/ContainerRunHandler.java
@@ -5,7 +5,7 @@ import io.serverlessworkflow.api.types.RunContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ContainerRunHandler implements RunHandler<RunContainer> {
+public final class ContainerRunHandler implements RunHandler<RunContainer> {
     private static final Logger log = LoggerFactory.getLogger(ContainerRunHandler.class);
 
     @Override

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/RunHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/RunHandler.java
@@ -2,6 +2,7 @@ package com.amannmalik.workflow.runtime.task.run.handler;
 
 import dev.restate.sdk.WorkflowContext;
 
-public interface RunHandler<T> {
-  void handle(WorkflowContext ctx, T run);
+public sealed interface RunHandler<T>
+        permits ContainerRunHandler, WorkflowRunHandler, ScriptRunHandler, ShellRunHandler {
+    void handle(WorkflowContext ctx, T run);
 }

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/ScriptRunHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/ScriptRunHandler.java
@@ -5,7 +5,7 @@ import io.serverlessworkflow.api.types.RunScript;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ScriptRunHandler implements RunHandler<RunScript> {
+public final class ScriptRunHandler implements RunHandler<RunScript> {
     private static final Logger log = LoggerFactory.getLogger(ScriptRunHandler.class);
 
     @Override

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/ShellRunHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/ShellRunHandler.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ShellRunHandler implements RunHandler<RunShell> {
+public final class ShellRunHandler implements RunHandler<RunShell> {
   private static final Logger log = LoggerFactory.getLogger(ShellRunHandler.class);
 
   @Override

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/WorkflowRunHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/run/handler/WorkflowRunHandler.java
@@ -8,7 +8,7 @@ import io.serverlessworkflow.api.types.Workflow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WorkflowRunHandler implements RunHandler<RunWorkflow> {
+public final class WorkflowRunHandler implements RunHandler<RunWorkflow> {
     private static final Logger log = LoggerFactory.getLogger(WorkflowRunHandler.class);
 
     @Override


### PR DESCRIPTION
## Summary
- embrace sealed interfaces and pattern matching for RunTaskService
- simplify WaitTaskService logic
- streamline YAML in EndToEndTest using text blocks
- use Java records for operator spec and status

## Testing
- `./mvnw -DskipTests install`

------
https://chatgpt.com/codex/tasks/task_e_684f2a42f2448324ad1d317175f5f026