### PR TITLE
Use Optional to guard against null values

### DIFF
--- a/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/reconciler/DurableWorkflowReconciler.java
+++ b/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/reconciler/DurableWorkflowReconciler.java
@@ -18,10 +18,10 @@ public class DurableWorkflowReconciler implements Reconciler<DurableWorkflow> {
     public UpdateControl<DurableWorkflow> reconcile(DurableWorkflow desired, Context context) {
         var client = context.getClient();
         var name = desired.getMetadata().getName();
-        var namespace = desired.getMetadata().getNamespace();
-        if (namespace == null || namespace.isBlank()) {
-            namespace = "default";
-        }
+        var namespace =
+                java.util.Optional.ofNullable(desired.getMetadata().getNamespace())
+                        .filter(s -> !s.isBlank())
+                        .orElse("default");
 
         Deployment existing = client.apps().deployments().inNamespace(namespace).withName(name).get();
         if (existing == null) {

--- a/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/service/WorkflowServlet.java
+++ b/durable-workflow-operator/src/main/java/com/amannmalik/workflow/operator/service/WorkflowServlet.java
@@ -29,11 +29,11 @@ public class WorkflowServlet extends HttpServlet {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
             mapper.registerModule(new JavaTimeModule());
             DurableWorkflow workflow = mapper.readValue(req.getInputStream(), DurableWorkflow.class);
-            String ns = workflow.getMetadata().getNamespace();
-            if (ns == null || ns.isBlank()) {
-                ns = "default";
-                workflow.getMetadata().setNamespace(ns);
-            }
+            String ns =
+                    java.util.Optional.ofNullable(workflow.getMetadata().getNamespace())
+                            .filter(s -> !s.isBlank())
+                            .orElse("default");
+            workflow.getMetadata().setNamespace(ns);
             client.resource(workflow).inNamespace(ns).createOrReplace();
             resp.setStatus(HttpServletResponse.SC_CREATED);
         } catch (Exception e) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/ExpressionResolver.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/ExpressionResolver.java
@@ -25,13 +25,13 @@ class ExpressionResolver {
     private ExpressionResolver() {
     }
 
-    static String resolveExpressions(WorkflowContext ctx, String value) {
+    static java.util.Optional<String> resolveExpressions(WorkflowContext ctx, String value) {
         if (value == null) {
-            return null;
+            return java.util.Optional.empty();
         }
         value = substitute(ctx, value, Pattern.compile("\\$\\{([^}]+)}"));
         value = substitute(ctx, value, Pattern.compile("\\{([^}]+)}"));
-        return value;
+        return java.util.Optional.of(value);
     }
 
     private static String substitute(WorkflowContext ctx, String value, Pattern pattern) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/GrpcCallHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/GrpcCallHandler.java
@@ -102,7 +102,9 @@ public class GrpcCallHandler implements CallHandler<CallGRPC> {
             } else {
                 protoStr = ep.toString();
             }
-            protoStr = ExpressionResolver.resolveExpressions(ctx, protoStr);
+            protoStr =
+                    ExpressionResolver.resolveExpressions(ctx, protoStr)
+                            .orElseThrow();
             Path protoPath = Path.of(URI.create(protoStr));
 
             FileDescriptorSet fdset;

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/HttpCallHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/HttpCallHandler.java
@@ -37,7 +37,9 @@ public class HttpCallHandler implements CallHandler<CallHTTP> {
         }
         Object ep = with.getEndpoint().get();
         String epStr = ep instanceof URI u ? u.toString() : ep.toString();
-        epStr = ExpressionResolver.resolveExpressions(ctx, epStr);
+        epStr =
+                ExpressionResolver.resolveExpressions(ctx, epStr)
+                        .orElseThrow();
         URI uri = URI.create(epStr);
 
         if (with.getQuery() != null && with.getQuery().getHTTPQuery() != null) {
@@ -49,7 +51,10 @@ public class HttpCallHandler implements CallHandler<CallHTTP> {
                         (k, v) ->
                                 sb.append(k)
                                         .append("=")
-                                        .append(ExpressionResolver.resolveExpressions(ctx, v))
+                                        .append(
+                                                ExpressionResolver
+                                                        .resolveExpressions(ctx, v)
+                                                        .orElse("") )
                                         .append("&"));
                 sb.setLength(sb.length() - 1);
                 uri = URI.create(sb.toString());
@@ -63,7 +68,13 @@ public class HttpCallHandler implements CallHandler<CallHTTP> {
             with.getHeaders()
                     .getHTTPHeaders()
                     .getAdditionalProperties()
-                    .forEach((k, v) -> builder.header(k, ExpressionResolver.resolveExpressions(ctx, v)));
+                    .forEach(
+                            (k, v) ->
+                                    builder.header(
+                                            k,
+                                            ExpressionResolver
+                                                    .resolveExpressions(ctx, v)
+                                                    .orElse("")));
         }
 
         Object body = with.getBody();
@@ -71,7 +82,10 @@ public class HttpCallHandler implements CallHandler<CallHTTP> {
             if (body instanceof String s) {
                 builder.method(
                         method,
-                        BodyPublishers.ofString(ExpressionResolver.resolveExpressions(ctx, s)));
+                        BodyPublishers.ofString(
+                                ExpressionResolver
+                                        .resolveExpressions(ctx, s)
+                                        .orElse("")));
             } else {
                 builder.method(method, BodyPublishers.noBody());
             }


### PR DESCRIPTION
## Summary
- use `Optional` in `WorkflowServlet` to handle namespaces
- use `Optional` in `DurableWorkflowReconciler`
- return `Optional` in `ExpressionResolver`
- adapt call sites in `GrpcCallHandler` and `HttpCallHandler`

## Testing
- `./mvnw clean install`

------
https://chatgpt.com/codex/tasks/task_e_684f367bd27c8324ab7485e2e25131f1