### PR TITLE
Implement function call support

### DIFF
--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/WorkflowRunner.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/WorkflowRunner.java
@@ -7,6 +7,7 @@ import com.amannmalik.workflow.runtime.event.EventBus;
 import com.amannmalik.workflow.runtime.task.ListenTaskService;
 import com.amannmalik.workflow.runtime.task.SwitchTaskService;
 import com.amannmalik.workflow.runtime.task.WorkflowTaskService;
+import com.amannmalik.workflow.runtime.task.call.CallTaskService;
 import dev.restate.sdk.HandlerRunner;
 import dev.restate.sdk.HandlerRunner.Options;
 import dev.restate.sdk.WorkflowContext;
@@ -79,6 +80,12 @@ public class WorkflowRunner {
             return;
         }
 
+        if (input.getUse() != null && input.getUse().getFunctions() != null) {
+            ctx.set(
+                    CallTaskService.FUNCTIONS,
+                    input.getUse().getFunctions().getAdditionalProperties());
+        }
+
         Map<String, Integer> index = new HashMap<>();
         for (int i = 0; i < taskItems.size(); i++) {
             index.put(taskItems.get(i).getName(), i);
@@ -122,6 +129,7 @@ public class WorkflowRunner {
             }
             i++;
         }
+        ctx.clear(CallTaskService.FUNCTIONS);
     }
 
     public static void main(String[] args) {

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/CallTaskService.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/CallTaskService.java
@@ -24,6 +24,8 @@ import java.util.Map;
 public class CallTaskService {
 
     public static final StateKey<Object> RESULT = StateKey.of("call-result", Object.class);
+    public static final StateKey<Map<String, io.serverlessworkflow.api.types.Task>> FUNCTIONS =
+            StateKey.of("workflow-functions", new dev.restate.serde.TypeRef<>() {});
     private static final Logger log = LoggerFactory.getLogger(CallTaskService.class);
     private static final Map<Class<?>, CallHandler<?>> HANDLERS =
             Map.of(

--- a/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/FunctionCallHandler.java
+++ b/durable-workflow-runtime/src/main/java/com/amannmalik/workflow/runtime/task/call/handler/FunctionCallHandler.java
@@ -1,21 +1,86 @@
 package com.amannmalik.workflow.runtime.task.call.handler;
 
+import com.amannmalik.workflow.runtime.Services;
+import com.amannmalik.workflow.runtime.task.call.CallTaskService;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.restate.sdk.WorkflowContext;
 import dev.restate.sdk.common.StateKey;
 import io.serverlessworkflow.api.types.CallFunction;
+import io.serverlessworkflow.api.types.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+
 public class FunctionCallHandler implements CallHandler<CallFunction> {
     private static final Logger log = LoggerFactory.getLogger(FunctionCallHandler.class);
+    private static final ObjectMapper MAPPER;
     private final StateKey<Object> resultKey;
 
     public FunctionCallHandler(StateKey<Object> resultKey) {
         this.resultKey = resultKey;
     }
 
+    static {
+        MAPPER = new ObjectMapper(new YAMLFactory());
+        MAPPER.registerModule(new JavaTimeModule());
+        MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
     @Override
     public void handle(WorkflowContext ctx, CallFunction call) {
-        log.info("Call function not implemented: {}", call);
+        String name = call.getCall();
+        if (name == null || name.isBlank()) {
+            return;
+        }
+
+        Map<String, Task> funcs = ctx.get(CallTaskService.FUNCTIONS).orElse(Map.of());
+        Task fn = funcs.get(name);
+        if (fn != null) {
+            Map<String, Object> args = call.getWith() == null ? Map.of() : call.getWith().getAdditionalProperties();
+            Map<String, Object> prev = new HashMap<>();
+            for (var e : args.entrySet()) {
+                StateKey<Object> k = StateKey.of(e.getKey(), Object.class);
+                ctx.get(k).ifPresent(v -> prev.put(e.getKey(), v));
+                ctx.set(k, e.getValue());
+            }
+            Services.callService(ctx, "WorkflowTaskService", "execute", fn, Void.class).await();
+            for (var e : args.entrySet()) {
+                StateKey<Object> k = StateKey.of(e.getKey(), Object.class);
+                if (prev.containsKey(e.getKey())) {
+                    ctx.set(k, prev.get(e.getKey()));
+                } else {
+                    ctx.clear(k);
+                }
+            }
+            return;
+        }
+
+        try {
+            String url = toRawUrl(name);
+            HttpRequest req = HttpRequest.newBuilder(URI.create(url)).GET().build();
+            HttpResponse<String> resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+            Task task = MAPPER.readValue(resp.body(), Task.class);
+            Services.callService(ctx, "WorkflowTaskService", "execute", task, Void.class).await();
+        } catch (Exception e) {
+            log.error("Failed to execute function {}", name, e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String toRawUrl(String url) {
+        if (url.startsWith("https://github.com/")) {
+            url = url.replaceFirst("https://github.com/", "https://raw.githubusercontent.com/");
+            url = url.replaceFirst("/tree/", "/refs/heads/");
+        }
+        return url;
     }
 }


### PR DESCRIPTION
## Summary
- add function registry state for call tasks
- store workflow functions in context when running
- implement loading and executing referenced functions

## Testing
- `./mvnw clean install`

------
https://chatgpt.com/codex/tasks/task_e_684f576e28508324bafa61fd45c6bbb9